### PR TITLE
🔀 :: (#108) SlackMessage 이미지 사이드에도 색깔 있도록 추가 && 메소드 분리

### DIFF
--- a/report-application/src/main/kotlin/com/xquare/v2servicereport/report/api/impl/ReportApiImpl.kt
+++ b/report-application/src/main/kotlin/com/xquare/v2servicereport/report/api/impl/ReportApiImpl.kt
@@ -40,7 +40,7 @@ class ReportApiImpl(
                         imageUrl = imageUrl,
                         reportId = reportId,
                     )
-                }
+                },
             )
         }
 

--- a/report-application/src/main/kotlin/com/xquare/v2servicereport/report/api/impl/ReportApiImpl.kt
+++ b/report-application/src/main/kotlin/com/xquare/v2servicereport/report/api/impl/ReportApiImpl.kt
@@ -34,13 +34,14 @@ class ReportApiImpl(
         )
 
         if (imageUrls.isNotEmpty()) {
-            val reportImages = imageUrls.map { imageUrl ->
-                ReportImage(
-                    imageUrl = imageUrl,
-                    reportId = reportId,
-                )
-            }
-            commandReportImageSpi.saveAllReportImage(reportImages)
+            commandReportImageSpi.saveAllReportImage(
+                imageUrls.map { imageUrl ->
+                    ReportImage(
+                        imageUrl = imageUrl,
+                        reportId = reportId,
+                    )
+                }
+            )
         }
 
         sendWebhookSpi.sendWebhookEvent(

--- a/report-infrastructure/src/main/kotlin/com/xquare/v2servicereport/webhook/SendWebhookEventHandler.kt
+++ b/report-infrastructure/src/main/kotlin/com/xquare/v2servicereport/webhook/SendWebhookEventHandler.kt
@@ -38,23 +38,20 @@ class SendWebhookEventHandler(
     private fun createReportReason(reason: String, category: String, userName: String) =
         "$REPORT_USER_NAME : $userName\n$REPORT_REASON : $reason\n$REPORT_CATEGORY : $category"
 
-    private fun SlackAttachment.createSlackAttachment(errorReason: String) {
-        this.apply {
-            setTitle(REPORT_MESSAGE)
-            setText(errorReason)
-            setColor(MESSAGE_COLOR)
-            setFallback(FALLBACK)
-        }
+    private fun SlackMessage.createSlackImage(imageUrls: List<String>) {
+        imageUrls.map { imageUrl -> this.addAttachments(SlackAttachment().createSlackImageAttachment(imageUrl)) }
     }
 
-    private fun SlackMessage.createSlackImage(imageUrls: List<String>) {
-        imageUrls.map { imageUrl ->
-            this.addAttachments(
-                SlackAttachment().apply {
-                    setImageUrl(imageUrl)
-                    setFallback(FALLBACK)
-                },
-            )
-        }
+    private fun SlackAttachment.createSlackAttachment(errorReason: String) = this.apply {
+        setTitle(REPORT_MESSAGE)
+        setText(errorReason)
+        setFallback(FALLBACK)
+        setColor(MESSAGE_COLOR)
+    }
+
+    private fun SlackAttachment.createSlackImageAttachment(imageUrl: String) = this.apply {
+        setImageUrl(imageUrl)
+        setFallback(FALLBACK)
+        setColor(MESSAGE_COLOR)
     }
 }


### PR DESCRIPTION
<img width="392" alt="스크린샷 2023-06-14 오후 12 18 30" src="https://github.com/team-xquare/v2-service-report/assets/101508190/3d53decc-576c-4ccb-a17a-3a0fba10ba73">
